### PR TITLE
Correccion de bug al momento crear usuario

### DIFF
--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/controller/UsuarioController.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/controller/UsuarioController.java
@@ -59,7 +59,8 @@ public class UsuarioController {
     public ResponseEntity<?> crear(@RequestBody Map<String, String> body, @RequestHeader(value = "Authorization", required = false) String authHeader) {
         try {
             Sesion sesion = autenticar(authHeader);
-            Usuario nuevo = usuarioService.crear(body, sesion.getRole());
+            String usuario = sesion.getNombre();
+            Usuario nuevo = usuarioService.crear(body, sesion.getRole(), usuario);
             return ResponseEntity.status(HttpStatus.CREATED).body(nuevo);
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/service/UsuarioService.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/service/UsuarioService.java
@@ -41,7 +41,7 @@ public class UsuarioService {
         return false;
     }
 
-    public Usuario crear(Map<String, String> datos, Role rolCreador) {
+    public Usuario crear(Map<String, String> datos, Role rolCreador, String usuarioDelCambio) {
         Role rolNuevoUsuario = Role.valueOf(datos.get("role"));
 
         if (!tienePermisoSobreRol(rolCreador, rolNuevoUsuario)) {
@@ -58,6 +58,7 @@ public class UsuarioService {
             datos.get("password"),
             rolNuevoUsuario
         );
+        nuevo.addHistorial(new HistorialUsuario("Creación", "-", "-", LocalDateTime.now().toString(), usuarioDelCambio));
         
         usuarios.add(nuevo);
         return nuevo;


### PR DESCRIPTION
Cuando se creaba el usuario mediante un admin o un rol superior no se estaba guardo la informacion para luego mostrarla en el historial de cambios