### PR TITLE
[MAIN] Implementación - Resolución de bloqueo de repartidor en tiempo real mediante WebSockets

### DIFF
--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/config/DataSeed.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/config/DataSeed.java
@@ -11,6 +11,7 @@ import com.meditrack.back.app.repository.MailRepository;
 import com.meditrack.back.app.repository.MedicamentoRepository;
 import com.meditrack.back.app.repository.UsuarioRepository;
 
+
 @Component
 public class DataSeed implements CommandLineRunner {
 

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/controller/AlertaFatigaController.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/controller/AlertaFatigaController.java
@@ -1,0 +1,161 @@
+package com.meditrack.back.app.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.meditrack.back.app.model.AlertaFatiga;
+import com.meditrack.back.app.model.Role;
+import com.meditrack.back.app.model.Sesion;
+import com.meditrack.back.app.model.Usuario;
+import com.meditrack.back.app.service.AlertaFatigaService;
+import com.meditrack.back.app.service.AuthService;
+import com.meditrack.back.app.service.UsuarioService;
+
+@RestController
+@RequestMapping("/api/alertas-fatiga")
+@CrossOrigin(origins = "*")
+public class AlertaFatigaController {
+
+    private final AlertaFatigaService alertaFatigaService;
+    private final AuthService authService;
+    private final UsuarioService usuarioService;
+
+    public AlertaFatigaController(AlertaFatigaService alertaFatigaService,
+                                  AuthService authService,
+                                  UsuarioService usuarioService) {
+        this.alertaFatigaService = alertaFatigaService;
+        this.authService = authService;
+        this.usuarioService = usuarioService;
+    }
+
+    private Sesion autenticar(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new RuntimeException("Token requerido");
+        }
+        return authService.validar(authHeader.substring(7));
+    }
+
+    private Usuario obtenerUsuario(Sesion sesion) {
+        return usuarioService.buscarPorEmail(sesion.getEmail())
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+    }
+
+    /** Repartidor reporta que falló la validación de aptitud */
+    @PostMapping
+    public ResponseEntity<?> crearAlerta(@RequestHeader(value = "Authorization", required = false) String authHeader) {
+        try {
+            Sesion sesion = autenticar(authHeader);
+            Usuario repartidor = obtenerUsuario(sesion);
+
+            if (repartidor.getRole() != Role.REPARTIDOR) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("error", "Solo los repartidores pueden reportar alertas de fatiga"));
+            }
+
+            AlertaFatiga alerta = alertaFatigaService.crearAlerta(repartidor);
+            return ResponseEntity.status(HttpStatus.CREATED).body(alerta);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    /** Supervisor/Admin consulta todas las alertas */
+    @GetMapping
+    public ResponseEntity<?> obtenerTodas(@RequestHeader(value = "Authorization", required = false) String authHeader) {
+        try {
+            Sesion sesion = autenticar(authHeader);
+            Usuario usuario = obtenerUsuario(sesion);
+
+            if (usuario.getRole() != Role.SUPERVISOR && usuario.getRole() != Role.ADMINISTRADOR) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("error", "Sin permisos para ver alertas de fatiga"));
+            }
+
+            List<AlertaFatiga> alertas = alertaFatigaService.obtenerTodas();
+            return ResponseEntity.ok(alertas);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    /** Supervisor/Admin consulta solo alertas pendientes */
+    @GetMapping("/pendientes")
+    public ResponseEntity<?> obtenerPendientes(@RequestHeader(value = "Authorization", required = false) String authHeader) {
+        try {
+            Sesion sesion = autenticar(authHeader);
+            Usuario usuario = obtenerUsuario(sesion);
+
+            if (usuario.getRole() != Role.SUPERVISOR && usuario.getRole() != Role.ADMINISTRADOR) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("error", "Sin permisos para ver alertas de fatiga"));
+            }
+
+            return ResponseEntity.ok(alertaFatigaService.obtenerPendientes());
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    /** Repartidor consulta su alerta pendiente actual (para polling de estado) */
+    @GetMapping("/mi-alerta-pendiente")
+    public ResponseEntity<?> obtenerMiAlertaPendiente(@RequestHeader(value = "Authorization", required = false) String authHeader) {
+        try {
+            Sesion sesion = autenticar(authHeader);
+            Usuario repartidor = obtenerUsuario(sesion);
+
+            AlertaFatiga alerta = alertaFatigaService.obtenerAlertaPendienteDeRepartidor(repartidor.getId());
+            if (alerta == null) {
+                return ResponseEntity.ok(Map.of("estado", "SIN_ALERTA"));
+            }
+            return ResponseEntity.ok(alerta);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    /** Consultar una alerta por ID */
+    @GetMapping("/{id}")
+    public ResponseEntity<?> obtenerPorId(@PathVariable String id,
+                                          @RequestHeader(value = "Authorization", required = false) String authHeader) {
+        try {
+            autenticar(authHeader);
+            AlertaFatiga alerta = alertaFatigaService.obtenerPorId(id);
+            return ResponseEntity.ok(alerta);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    /** Supervisor registra su resolución sobre una alerta */
+    @PutMapping("/{id}/decision")
+    public ResponseEntity<?> procesarDecision(@PathVariable String id,
+                                              @RequestBody Map<String, String> body,
+                                              @RequestHeader(value = "Authorization", required = false) String authHeader) {
+        try {
+            Sesion sesion = autenticar(authHeader);
+            Usuario supervisor = obtenerUsuario(sesion);
+
+            String decision = body.get("decision");
+            String observaciones = body.get("observaciones");
+
+            if (decision == null || decision.isBlank()) {
+                return ResponseEntity.badRequest().body(Map.of("error", "La resolución es requerida"));
+            }
+            if (observaciones == null || observaciones.isBlank()) {
+                return ResponseEntity.badRequest().body(Map.of("error", "Las observaciones son requeridas"));
+            }
+
+            AlertaFatiga resuelta = alertaFatigaService.procesarDecision(id, decision, supervisor, observaciones);
+            return ResponseEntity.ok(resuelta);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Resolución inválida. Use BLOQUEADO o VALIDADO_FALLA"));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+}

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/model/AlertaFatiga.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/model/AlertaFatiga.java
@@ -1,0 +1,102 @@
+package com.meditrack.back.app.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "alertas_fatiga")
+public class AlertaFatiga {
+
+    @Id
+    private String id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "repartidor_id", nullable = false)
+    @JsonIgnoreProperties({"historial", "password"})
+    private Usuario repartidor;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "supervisor_id")
+    @JsonIgnoreProperties({"historial", "password"})
+    private Usuario supervisor;
+
+    @Column(name = "fecha_deteccion", nullable = false)
+    private LocalDateTime fechaDeteccion;
+
+    @Column(name = "fecha_decision")
+    private LocalDateTime fechaDecision;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EstadoAlertaFatiga estado = EstadoAlertaFatiga.PENDIENTE;
+
+    @Column(length = 500)
+    private String observaciones;
+
+    public AlertaFatiga() {
+        this.id = "ALF-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        this.fechaDeteccion = LocalDateTime.now();
+        this.estado = EstadoAlertaFatiga.PENDIENTE;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Usuario getRepartidor() {
+        return repartidor;
+    }
+
+    public void setRepartidor(Usuario repartidor) {
+        this.repartidor = repartidor;
+    }
+
+    public Usuario getSupervisor() {
+        return supervisor;
+    }
+
+    public void setSupervisor(Usuario supervisor) {
+        this.supervisor = supervisor;
+    }
+
+    public LocalDateTime getFechaDeteccion() {
+        return fechaDeteccion;
+    }
+
+    public void setFechaDeteccion(LocalDateTime fechaDeteccion) {
+        this.fechaDeteccion = fechaDeteccion;
+    }
+
+    public LocalDateTime getFechaDecision() {
+        return fechaDecision;
+    }
+
+    public void setFechaDecision(LocalDateTime fechaDecision) {
+        this.fechaDecision = fechaDecision;
+    }
+
+    public EstadoAlertaFatiga getEstado() {
+        return estado;
+    }
+
+    public void setEstado(EstadoAlertaFatiga estado) {
+        this.estado = estado;
+    }
+
+    public String getObservaciones() {
+        return observaciones;
+    }
+
+    public void setObservaciones(String observaciones) {
+        this.observaciones = observaciones;
+    }
+    
+}

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/model/EstadoAlertaFatiga.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/model/EstadoAlertaFatiga.java
@@ -1,0 +1,7 @@
+package com.meditrack.back.app.model;
+
+public enum EstadoAlertaFatiga {
+    PENDIENTE,
+    BLOQUEADO,
+    VALIDADO_FALLA
+}

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/model/EstadoEnvio.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/model/EstadoEnvio.java
@@ -34,5 +34,4 @@ public enum EstadoEnvio {
     public boolean permiteCancelacion(){
         return this != ENTREGADO && this != CANCELADO;
     }
-
 }

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/repository/AlertaFatigaRepository.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/repository/AlertaFatigaRepository.java
@@ -1,0 +1,21 @@
+package com.meditrack.back.app.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.meditrack.back.app.model.AlertaFatiga;
+import com.meditrack.back.app.model.EstadoAlertaFatiga;
+
+public interface AlertaFatigaRepository extends JpaRepository<AlertaFatiga, String> {
+
+    List<AlertaFatiga> findByEstadoOrderByFechaDeteccionDesc(EstadoAlertaFatiga estado);
+
+    List<AlertaFatiga> findAllByOrderByFechaDeteccionDesc();
+
+    Optional<AlertaFatiga> findFirstByRepartidorIdAndEstado(String repartidorId, EstadoAlertaFatiga estado);
+    
+    boolean existsByRepartidorIdAndEstado(String repartidorId, EstadoAlertaFatiga estado);
+
+}

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/service/AlertaFatigaService.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/service/AlertaFatigaService.java
@@ -1,0 +1,121 @@
+package com.meditrack.back.app.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.meditrack.back.app.model.AlertaFatiga;
+import com.meditrack.back.app.model.EstadoAlertaFatiga;
+import com.meditrack.back.app.model.Role;
+import com.meditrack.back.app.model.Usuario;
+import com.meditrack.back.app.repository.AlertaFatigaRepository;
+import com.meditrack.back.app.repository.UsuarioRepository;
+
+@Service
+public class AlertaFatigaService {
+
+    private final AlertaFatigaRepository alertaFatigaRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final UsuarioService usuarioService;
+    private final NotificacionService notificacionService;
+
+    public AlertaFatigaService(AlertaFatigaRepository alertaFatigaRepository,
+                               UsuarioRepository usuarioRepository,
+                               UsuarioService usuarioService,
+                               NotificacionService notificacionService) {
+        this.alertaFatigaRepository = alertaFatigaRepository;
+        this.usuarioRepository = usuarioRepository;
+        this.usuarioService = usuarioService;
+        this.notificacionService = notificacionService;
+    }
+
+    @Transactional
+    public AlertaFatiga crearAlerta(Usuario repartidor) {
+        if (alertaFatigaRepository.existsByRepartidorIdAndEstado(repartidor.getId(), EstadoAlertaFatiga.PENDIENTE)) {
+            return alertaFatigaRepository
+                    .findFirstByRepartidorIdAndEstado(repartidor.getId(), EstadoAlertaFatiga.PENDIENTE)
+                    .orElseThrow();
+        }
+
+        AlertaFatiga alerta = new AlertaFatiga();
+        alerta.setRepartidor(repartidor);
+
+        AlertaFatiga saved = alertaFatigaRepository.save(alerta);
+
+        List<Usuario> supervisores = usuarioRepository.findByRole(Role.SUPERVISOR);
+        for (Usuario supervisor : supervisores) {
+            try {
+                notificacionService.crearNotificacion(
+                    supervisor,
+                    "Alerta de Fatiga - " + repartidor.getNombre(),
+                    "El repartidor " + repartidor.getNombre() + " (DNI: " + repartidor.getDni() + ") no pudo superar la validación de aptitud. Se requiere tu resolución de bloqueo. Alerta ID: " + saved.getId()
+                );
+            } catch (Exception e) {
+                System.err.println("Error al notificar supervisor " + supervisor.getNombre() + ": " + e.getMessage());
+            }
+        }
+
+        return saved;
+    }
+
+    @Transactional
+    public AlertaFatiga procesarDecision(String alertaId, String decision, Usuario supervisor, String observaciones) {
+        AlertaFatiga alerta = alertaFatigaRepository.findById(alertaId)
+                .orElseThrow(() -> new RuntimeException("Alerta no encontrada"));
+
+        if (alerta.getEstado() != EstadoAlertaFatiga.PENDIENTE) {
+            throw new RuntimeException("Esta alerta ya fue resuelta");
+        }
+
+        if (supervisor.getRole() != Role.SUPERVISOR && supervisor.getRole() != Role.ADMINISTRADOR) {
+            throw new RuntimeException("No tienes permisos para resolver alertas de fatiga");
+        }
+
+        EstadoAlertaFatiga nuevoEstado = EstadoAlertaFatiga.valueOf(decision);
+        alerta.setEstado(nuevoEstado);
+        alerta.setSupervisor(supervisor);
+        alerta.setFechaDecision(LocalDateTime.now());
+        alerta.setObservaciones(observaciones);
+
+        if (nuevoEstado == EstadoAlertaFatiga.BLOQUEADO) {
+            usuarioService.bloquearUsuario(alerta.getRepartidor().getId(), supervisor);
+            notificacionService.crearNotificacion(
+                alerta.getRepartidor(),
+                "Acceso bloqueado por supervisor",
+                "El supervisor " + supervisor.getNombre() + " decidió bloquear tu acceso por fatiga detectada. Motivo: " + (observaciones != null ? observaciones : "Sin observaciones") + ". El bloqueo tiene una duración de 6 horas.",
+                java.util.Map.of("tipo", "DECISION_FATIGA", "decision", "BLOQUEADO")
+            );
+        } else if (nuevoEstado == EstadoAlertaFatiga.VALIDADO_FALLA) {
+            notificacionService.crearNotificacion(
+                alerta.getRepartidor(),
+                "Validación de aptitud: falla técnica confirmada",
+                "El supervisor " + supervisor.getNombre() + " validó que el inconveniente fue una falla técnica. Puedes intentar iniciar la ruta nuevamente.",
+                java.util.Map.of("tipo", "DECISION_FATIGA", "decision", "VALIDADO_FALLA")
+            );
+        }
+
+        return alertaFatigaRepository.save(alerta);
+    }
+
+    public List<AlertaFatiga> obtenerPendientes() {
+        return alertaFatigaRepository.findByEstadoOrderByFechaDeteccionDesc(EstadoAlertaFatiga.PENDIENTE);
+    }
+
+    public List<AlertaFatiga> obtenerTodas() {
+        return alertaFatigaRepository.findAllByOrderByFechaDeteccionDesc();
+    }
+
+    public AlertaFatiga obtenerPorId(String id) {
+        return alertaFatigaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Alerta no encontrada"));
+    }
+
+    public AlertaFatiga obtenerAlertaPendienteDeRepartidor(String repartidorId) {
+        return alertaFatigaRepository
+                .findFirstByRepartidorIdAndEstado(repartidorId, EstadoAlertaFatiga.PENDIENTE)
+                .orElse(null);
+    }
+
+}

--- a/src/meditrack-back/src/main/java/com/meditrack/back/app/service/NotificacionService.java
+++ b/src/meditrack-back/src/main/java/com/meditrack/back/app/service/NotificacionService.java
@@ -1,5 +1,6 @@
 package com.meditrack.back.app.service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +42,27 @@ public class NotificacionService {
                 "leido", false
             )
         );
+
+        return notificacion;
+    }
+
+    @Transactional
+    public Notificacion crearNotificacion(Usuario usuarioDestino, String titulo, String mensaje, Map<String, Object> extraWsData) {
+        if (usuarioDestino == null) {
+            throw new IllegalArgumentException("El usuario destino de la notificación no puede ser nulo");
+        }
+        Notificacion notificacion = new Notificacion(usuarioDestino, titulo, mensaje);
+        notificacionRepository.save(notificacion);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("id", notificacion.getId());
+        payload.put("titulo", notificacion.getTitulo());
+        payload.put("mensaje", notificacion.getMensaje());
+        payload.put("fechaCreacion", notificacion.getFechaCreacion());
+        payload.put("leido", false);
+        if (extraWsData != null) payload.putAll(extraWsData);
+
+        messagingTemplate.convertAndSend("/topic/notificaciones/" + usuarioDestino.getId(), payload);
 
         return notificacion;
     }

--- a/src/meditrack-front/src/App.jsx
+++ b/src/meditrack-front/src/App.jsx
@@ -31,8 +31,7 @@ import DashboardKPI from './pages/Reportes/DashboardKPI';
 import Mails from './pages/Mails/Mails';
 import ReclamoCambioDatos from './pages/ReclamoCambioDato/ReclamoCambioDatos';
 import Repartidores from './pages/Usuarios/Repartidores';
-
-
+import AlertasFatiga from './pages/Fatiga/AlertasFatiga';
 
 function App() {
   return (
@@ -72,6 +71,7 @@ function App() {
               <Route path="/transportes" element={<ProtectedRoute roles={['ADMINISTRADOR', 'SUPERVISOR', 'REPARTIDOR']}><Transportes /></ProtectedRoute>} />
               <Route path="/mails" element={ <ProtectedRoute roles={['SUPERVISOR', 'ADMINISTRADOR']}><Mails /></ProtectedRoute> }/>
               <Route path="/repartidor" element={ <ProtectedRoute roles={['SUPERVISOR', 'ADMINISTRADOR']}><Repartidores /></ProtectedRoute> }/>
+              <Route path="/alertas-fatiga" element={ <ProtectedRoute roles={['SUPERVISOR', 'ADMINISTRADOR']}><AlertasFatiga /></ProtectedRoute> }/>
             </Route>
             <Route path="*" element={<Navigate to="/menu" replace />} />
           </Routes>

--- a/src/meditrack-front/src/pages/Fatiga/AlertasFatiga.jsx
+++ b/src/meditrack-front/src/pages/Fatiga/AlertasFatiga.jsx
@@ -1,0 +1,346 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CheckCircle } from 'lucide-react';
+import { getAlertasFatiga, procesarDecisionFatiga } from '../../services/api';
+
+const ESTADO_LABEL = {
+    PENDIENTE: 'PENDIENTE',
+    BLOQUEADO: 'BLOQUEADO',
+    VALIDADO_FALLA: 'FALLA TÉCNICA',
+};
+
+const ESTADO_COLORS = {
+    PENDIENTE: '#F59E0B',
+    BLOQUEADO: '#DC2626',
+    VALIDADO_FALLA: '#16A34A',
+};
+
+function formatFecha(fechaStr) {
+    if (!fechaStr) return '–';
+    const d = new Date(fechaStr);
+    return d.toLocaleString('es-AR', { dateStyle: 'short', timeStyle: 'short' });
+}
+
+function ModalDecision({ alerta, onClose, onDecidido }) {
+    const [decision, setDecision] = useState('');
+    const [observaciones, setObservaciones] = useState('');
+    const [cargando, setCargando] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleSubmit = async () => {
+        if (!decision) { setError('Seleccioná una decisión.'); return; }
+        if (!observaciones.trim()) { setError('Las observaciones son obligatorias.'); return; }
+        setCargando(true);
+        setError('');
+        try {
+            await procesarDecisionFatiga(alerta.id, { decision, observaciones });
+            onDecidido();
+        } catch (e) {
+            setError(e.message);
+            setCargando(false);
+        }
+    };
+
+    return (
+        <div style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000
+        }}>
+            <div className="card" style={{ padding: '32px', width: '100%', maxWidth: '480px' }}>
+                <h2 style={{ margin: '0 0 4px', fontSize: '20px', fontWeight: '800', color: '#111827' }}>
+                    Resolución sobre alerta de fatiga
+                </h2>
+                <p style={{ color: '#6b7280', fontSize: '14px', margin: '0 0 24px' }}>
+                    Repartidor: <strong style={{ color: '#111827' }}>{alerta.repartidor?.nombre}</strong>
+                    &nbsp;·&nbsp;
+                    Detectado: <strong style={{ color: '#111827' }}>{formatFecha(alerta.fechaDeteccion)}</strong>
+                </p>
+
+                <div style={{ marginBottom: '16px' }}>
+                    <label style={{ fontWeight: '700', fontSize: '13px', display: 'block', marginBottom: '8px', color: '#374151' }}>
+                        Resolución *
+                    </label>
+                    <div style={{ display: 'flex', gap: '10px' }}>
+                        <button
+                            onClick={() => setDecision('BLOQUEADO')}
+                            style={{
+                                flex: 1, padding: '11px 12px', borderRadius: '10px',
+                                border: `2px solid ${decision === 'BLOQUEADO' ? '#EF4444' : '#d1d5db'}`,
+                                background: decision === 'BLOQUEADO' ? '#FEF2F2' : '#fff',
+                                cursor: 'pointer', fontWeight: '700', fontSize: '13px', color: '#EF4444'
+                            }}
+                        >
+                            Bloquear
+                        </button>
+                        <button
+                            onClick={() => setDecision('VALIDADO_FALLA')}
+                            style={{
+                                flex: 1, padding: '11px 12px', borderRadius: '10px',
+                                border: `2px solid ${decision === 'VALIDADO_FALLA' ? '#10b981' : '#d1d5db'}`,
+                                background: decision === 'VALIDADO_FALLA' ? '#F0FDF4' : '#fff',
+                                cursor: 'pointer', fontWeight: '700', fontSize: '13px', color: '#10b981'
+                            }}
+                        >
+                            Validar falla técnica
+                        </button>
+                    </div>
+                    {decision === 'BLOQUEADO' && (
+                        <p style={{ fontSize: '12px', color: '#6b7280', margin: '6px 0 0' }}>
+                            El repartidor quedará bloqueado 6 horas y recibirá una notificación.
+                        </p>
+                    )}
+                    {decision === 'VALIDADO_FALLA' && (
+                        <p style={{ fontSize: '12px', color: '#6b7280', margin: '6px 0 0' }}>
+                            Se registra como falla técnica. El repartidor podrá reintentar la validación.
+                        </p>
+                    )}
+                </div>
+
+                <div style={{ marginBottom: '20px' }}>
+                    <label style={{ fontWeight: '700', fontSize: '13px', display: 'block', marginBottom: '8px', color: '#374151' }}>
+                        Observaciones * <span style={{ fontWeight: '400', color: '#6b7280' }}>(obligatorio)</span>
+                    </label>
+                    <textarea
+                        value={observaciones}
+                        onChange={e => setObservaciones(e.target.value)}
+                        placeholder="Describí el motivo de tu decisión..."
+                        rows={3}
+                        style={{
+                            width: '100%', padding: '10px 12px', borderRadius: '10px',
+                            border: '1px solid #d1d5db', fontSize: '14px', resize: 'vertical',
+                            boxSizing: 'border-box', fontFamily: 'inherit', color: '#111827'
+                        }}
+                    />
+                </div>
+
+                {error && (
+                    <p style={{ color: '#EF4444', fontSize: '13px', marginBottom: '12px' }}>{error}</p>
+                )}
+
+                <div style={{ display: 'flex', gap: '10px' }}>
+                    <button
+                        className="btn btn-secondary"
+                        onClick={onClose}
+                        disabled={cargando}
+                        style={{ flex: 1 }}
+                    >
+                        CANCELAR
+                    </button>
+                    <button
+                        className="btn btn-primary"
+                        onClick={handleSubmit}
+                        disabled={cargando || !decision}
+                        style={{
+                            flex: 1,
+                            opacity: cargando || !decision ? 0.5 : 1,
+                            cursor: cargando || !decision ? 'not-allowed' : 'pointer'
+                        }}
+                    >
+                        {cargando ? 'REGISTRANDO...' : 'CONFIRMAR'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function AlertasFatiga() {
+    const navigate = useNavigate();
+    const [alertas, setAlertas] = useState([]);
+    const [cargando, setCargando] = useState(true);
+    const [error, setError] = useState('');
+    const [filtro, setFiltro] = useState('TODOS');
+    const [alertaSeleccionada, setAlertaSeleccionada] = useState(null);
+
+    const cargarAlertas = useCallback(async () => {
+        try {
+            const data = await getAlertasFatiga();
+            setAlertas(data);
+            setError('');
+        } catch (e) {
+            setError(e.message || 'Error al cargar alertas');
+        } finally {
+            setCargando(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        cargarAlertas();
+        const interval = setInterval(cargarAlertas, 30000);
+        return () => clearInterval(interval);
+    }, [cargarAlertas]);
+
+    const alertasFiltradas = alertas.filter(a =>
+        filtro === 'TODOS' ? true : a.estado === filtro
+    );
+
+    const pendienteCount = alertas.filter(a => a.estado === 'PENDIENTE').length;
+
+    return (
+        <div className="container">
+            <style>{`
+                @media (max-width: 768px) {
+                    .mobile-hidden { display: none !important; }
+                }
+            `}</style>
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: '20px', marginBottom: '24px' }}>
+                <button className="btn btn-secondary" onClick={() => navigate(-1)}>
+                    VOLVER
+                </button>
+                <h1 style={{ fontSize: '28px', fontWeight: '800', color: '#111827', margin: 0 }}>
+                    Alertas de fatiga
+                </h1>
+                {pendienteCount > 0 && (
+                    <span style={{
+                        backgroundColor: '#FEF3C7', color: '#92400E',
+                        borderRadius: '999px', padding: '4px 12px',
+                        fontSize: '12px', fontWeight: '700'
+                    }}>
+                        {pendienteCount} pendiente{pendienteCount > 1 ? 's' : ''}
+                    </span>
+                )}
+            </div>
+
+            <div className="card" style={{ padding: '16px 20px', marginBottom: '24px' }}>
+                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+                    {['TODOS', 'PENDIENTE', 'BLOQUEADO', 'VALIDADO_FALLA'].map(f => {
+                        const label = f === 'TODOS' ? 'TODOS' : ESTADO_LABEL[f];
+                        const activo = filtro === f;
+                        return (
+                            <button
+                                key={f}
+                                onClick={() => setFiltro(f)}
+                                style={{
+                                    padding: '7px 16px', borderRadius: '999px',
+                                    border: `1px solid ${activo ? '#111827' : '#d1d5db'}`,
+                                    background: activo ? '#111827' : '#fff',
+                                    color: activo ? '#fff' : '#374151',
+                                    cursor: 'pointer', fontWeight: '600', fontSize: '12px'
+                                }}
+                            >
+                                {label}{f === 'PENDIENTE' && pendienteCount > 0 ? ` (${pendienteCount})` : ''}
+                            </button>
+                        );
+                    })}
+                    <button
+                        className="btn btn-secondary"
+                        onClick={cargarAlertas}
+                        style={{ marginLeft: 'auto', fontSize: '12px', padding: '7px 14px' }}
+                    >
+                        ACTUALIZAR
+                    </button>
+                </div>
+            </div>
+
+            {error && (
+                <div style={{
+                    background: '#FEF2F2', border: '1px solid #FCA5A5', borderRadius: '12px',
+                    padding: '14px 16px', color: '#DC2626', marginBottom: '16px', fontSize: '14px'
+                }}>
+                    {error}
+                </div>
+            )}
+
+            {cargando ? (
+                <div style={{ textAlign: 'center', padding: '60px', color: '#6b7280' }}>
+                    Cargando alertas...
+                </div>
+            ) : alertasFiltradas.length === 0 ? (
+                <div style={{
+                    textAlign: 'center', padding: '60px', color: '#6b7280',
+                    background: '#f9fafb', borderRadius: '16px', border: '1px dashed #e5e7eb'
+                }}>
+                    {filtro === 'PENDIENTE' ? 'No hay alertas pendientes.' : 'No hay alertas registradas.'}
+                </div>
+            ) : (
+                <div className="table-responsive-container">
+                    <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '15px' }}>
+                        <thead>
+                            <tr>
+                                <th>Repartidor</th>
+                                <th className="mobile-hidden">Detectado</th>
+                                <th className="mobile-hidden">Estado</th>
+                                <th className="mobile-hidden">Supervisor / Observaciones</th>
+                                <th style={{ textAlign: 'center' }}>Acción</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {alertasFiltradas.map(alerta => (
+                                <tr key={alerta.id}>
+                                    <td style={{ padding: '16px 20px', verticalAlign: 'middle' }}>
+                                        <div style={{ fontWeight: '700', color: '#111827', fontSize: '15px' }}>
+                                            {alerta.repartidor?.nombre}
+                                        </div>
+                                        <div style={{ fontSize: '12px', color: '#6b7280', marginTop: '2px' }}>
+                                            DNI: {alerta.repartidor?.dni}
+                                        </div>
+                                    </td>
+                                    <td className="mobile-hidden" style={{ fontSize: '13px' }}>
+                                        {formatFecha(alerta.fechaDeteccion)}
+                                    </td>
+                                    <td className="mobile-hidden">
+                                        <span
+                                            className="status-tag"
+                                            style={{
+                                                backgroundColor: `${ESTADO_COLORS[alerta.estado]}15`,
+                                                color: ESTADO_COLORS[alerta.estado],
+                                            }}
+                                        >
+                                            {ESTADO_LABEL[alerta.estado]}
+                                        </span>
+                                    </td>
+                                    <td className="mobile-hidden" style={{ maxWidth: '240px' }}>
+                                        {alerta.supervisor ? (
+                                            <div>
+                                                <div style={{ fontSize: '13px', color: '#111827', fontWeight: '600' }}>
+                                                    {alerta.supervisor.nombre}
+                                                </div>
+                                                <div style={{ fontSize: '12px', color: '#6b7280', marginTop: '2px' }}>
+                                                    {formatFecha(alerta.fechaDecision)}
+                                                </div>
+                                                {alerta.observaciones && (
+                                                    <div style={{ fontSize: '12px', color: '#6b7280', marginTop: '2px', fontStyle: 'italic' }}>
+                                                        "{alerta.observaciones}"
+                                                    </div>
+                                                )}
+                                            </div>
+                                        ) : (
+                                            <span style={{ fontSize: '13px', color: '#9ca3af' }}>Sin resolver</span>
+                                        )}
+                                    </td>
+                                    <td style={{ textAlign: 'center', verticalAlign: 'middle' }}>
+                                        {alerta.estado === 'PENDIENTE' ? (
+                                            <button
+                                                className="action-icon-btn"
+                                                title="Decidir"
+                                                onClick={() => setAlertaSeleccionada(alerta)}
+                                            >
+                                                <CheckCircle size={18} color="#F59E0B" />
+                                            </button>
+                                        ) : (
+                                            <span style={{ fontSize: '12px', color: '#9ca3af' }}>–</span>
+                                        )}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            {alertaSeleccionada && (
+                <ModalDecision
+                    alerta={alertaSeleccionada}
+                    onClose={() => setAlertaSeleccionada(null)}
+                    onDecidido={() => {
+                        setAlertaSeleccionada(null);
+                        cargarAlertas();
+                    }}
+                />
+            )}
+        </div>
+    );
+}
+
+export default AlertasFatiga;

--- a/src/meditrack-front/src/pages/Home/MainMenu.jsx
+++ b/src/meditrack-front/src/pages/Home/MainMenu.jsx
@@ -13,7 +13,8 @@ import {
   History,
   CircleAlert,
   LayoutDashboard,
-  Mail
+  Mail,
+  AlertTriangle
 } from 'lucide-react';
 
 const MainMenu = () => {
@@ -58,6 +59,7 @@ const MainMenu = () => {
       rolesPermitidos: ['ADMINISTRADOR', 'SUPERVISOR', 'REPARTIDOR'],
       items: [
         { label: "Repartidor", icon: <Users size={32} />, path: "/repartidor", color: "#ec7f35", rolesPermitidos: ['ADMINISTRADOR', 'SUPERVISOR'] },
+        { label: "Alertas fatiga", icon: <AlertTriangle size={32} />, path: "/alertas-fatiga", color: "#d97706", rolesPermitidos: ['ADMINISTRADOR', 'SUPERVISOR'] },
         { label: "Asignaciones", icon: <NotepadText size={32} />, path: "/viajes", color: "#ec7f35", rolesPermitidos: ['REPARTIDOR'] },
         { label: "Transportes", icon: <Truck size={32} />, path: "/transportes", color: "#ec7f35", rolesPermitidos: ['ADMINISTRADOR', 'SUPERVISOR'] },
       ]

--- a/src/meditrack-front/src/pages/Viajes/ModalValidacionAptitud.jsx
+++ b/src/meditrack-front/src/pages/Viajes/ModalValidacionAptitud.jsx
@@ -325,9 +325,9 @@ export function PantallaBloqueo({ onContactarSupervisor }) {
                     </svg>
                 </div>
                 <span className="val-bloqueo-label">VIAJE BLOQUEADO</span>
-                <h2 className="val-bloqueo-title">No fue posible validar tu aptitud para iniciar este viaje.</h2>
+                <h2 className="val-bloqueo-title">Tu acceso fue bloqueado por un supervisor.</h2>
                 <p className="val-bloqueo-desc">
-                    Por motivos de seguridad, el recorrido permanecerá bloqueado hasta que un supervisor realice una verificación manual.
+                    Por motivos de seguridad, el recorrido permanecerá bloqueado durante 6 horas. Revisá tus notificaciones para más detalles.
                 </p>
                 <button
                     className="val-bloqueo-btn btn-action-hover"
@@ -338,6 +338,42 @@ export function PantallaBloqueo({ onContactarSupervisor }) {
                     </svg>
                     Contactar supervisor
                 </button>
+            </div>
+        </div>
+    );
+}
+
+export function PantallaEsperando() {
+
+    return (
+        <div className="val-bloqueo-screen animate-fade-in">
+            <div className="val-bloqueo-card animate-slide-up" style={{ borderTop: '4px solid #F59E0B' }}>
+                <div className="val-bloqueo-icon" style={{ color: '#F59E0B' }}>
+                    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+                        <circle cx="12" cy="12" r="10" />
+                        <polyline points="12 6 12 12 16 14" />
+                    </svg>
+                </div>
+                <span className="val-bloqueo-label" style={{ color: '#F59E0B' }}>PENDIENTE DE REVISIÓN</span>
+                <h2 className="val-bloqueo-title">Tu supervisor fue notificado</h2>
+                <p className="val-bloqueo-desc">
+                    “No fue posible verificar tu aptitud. Se notificó a tu supervisor para que revise el caso. Esta pantalla se actualizará automáticamente cuando haya una resolución.”
+                </p>
+                <div style={{
+                    marginTop: '16px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    color: '#6B7280',
+                    fontSize: '13px'
+                }}>
+                    <div style={{
+                        width: '8px', height: '8px', borderRadius: '50%',
+                        backgroundColor: '#F59E0B',
+                        animation: 'pulse 1.5s infinite'
+                    }} />
+                    Esperando resolución del supervisor...
+                </div>
             </div>
         </div>
     );

--- a/src/meditrack-front/src/pages/Viajes/Viajes.jsx
+++ b/src/meditrack-front/src/pages/Viajes/Viajes.jsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
-import { getRutas, getClientes, BASE_URL, getEnvioById, bloquearUsuario, getUsuarioById } from '../../services/api';
+import { useNotificacionesWS } from '../../hooks/useNotificacionesWS';
+import { getRutas, getClientes, BASE_URL, getEnvioById, reportarFatiga, getUsuarioById, getMiAlertaPendiente } from '../../services/api';
 import MapaRuta from '../../components/MapaRuta';
 import OfflineBanner from '../../components/OfflineBanner';
 import { iconos, DefaultIcon } from '../../util/Util';
-import { ModalValidacionAptitud, PantallaBloqueo } from './ModalValidacionAptitud';
+import { ModalValidacionAptitud, PantallaBloqueo, PantallaEsperando } from './ModalValidacionAptitud';
 import './Viajes.css';
 
 const obtenerNombreMes = (mesNum) => {
@@ -313,23 +314,45 @@ function Viajes() {
     }, [user]);
 
     const [viajeBlockeado, setViajeBlockeado] = useState(isBlocked());
+    const [alertaFatigaId, setAlertaFatigaId] = useState(null);
     const [modoTestMic, setModoTestMic] = useState(false);
+
+    const alertaFatigaIdRef = useRef(alertaFatigaId);
+    useEffect(() => { alertaFatigaIdRef.current = alertaFatigaId; }, [alertaFatigaId]);
+
+    useNotificacionesWS(user?.id, user?.token, useCallback((notif) => {
+        if (notif.tipo !== 'DECISION_FATIGA' || !alertaFatigaIdRef.current) return;
+        setAlertaFatigaId(null);
+        if (notif.decision === 'BLOQUEADO') {
+            getUsuarioById(user.id)
+                .then(u => updateUser({ estaBloqueado: u.estaBloqueado, fechaBloqueo: u.fechaBloqueo }))
+                .catch(() => {});
+            setViajeBlockeado(true);
+        }
+    }, [user?.id, updateUser]));
 
     useEffect(() => {
         setViajeBlockeado(isBlocked());
     }, [user, isBlocked]);
 
     useEffect(() => {
-        if (user && user.id) {
-            getUsuarioById(user.id)
-                .then(latestUser => {
-                    updateUser({
-                        estaBloqueado: latestUser.estaBloqueado,
-                        fechaBloqueo: latestUser.fechaBloqueo
-                    });
-                })
-                .catch(err => console.error("Error fetching latest user status on mount:", err));
-        }
+        if (!user?.id) return;
+        getUsuarioById(user.id)
+            .then(latestUser => {
+                updateUser({
+                    estaBloqueado: latestUser.estaBloqueado,
+                    fechaBloqueo: latestUser.fechaBloqueo
+                });
+            })
+            .catch(err => console.error("Error fetching latest user status on mount:", err));
+
+        getMiAlertaPendiente()
+            .then(alerta => {
+                if (alerta && alerta.id && alerta.estado === 'PENDIENTE') {
+                    setAlertaFatigaId(alerta.id);
+                }
+            })
+            .catch(() => {});
     }, []);
 
     const fetchRutas = async (silent = false) => {
@@ -847,15 +870,12 @@ function Viajes() {
                             setModoTestMic(false);
                         } else {
                             try {
-                                const updatedUser = await bloquearUsuario(user.id);
-                                updateUser({
-                                    estaBloqueado: updatedUser.estaBloqueado,
-                                    fechaBloqueo: updatedUser.fechaBloqueo
-                                });
-                                setViajeBlockeado(true);
+                                const alerta = await reportarFatiga();
+                                setAlertaFatigaId(alerta.id);
                             } catch (err) {
-                                console.error("Error al bloquear usuario en backend:", err);
-                                setViajeBlockeado(true);
+                                console.error("Error al reportar fatiga al supervisor:", err);
+                                // igual mostramos la pantalla de espera
+                                setAlertaFatigaId('error');
                             }
                         }
                     }}
@@ -866,9 +886,13 @@ function Viajes() {
                 />
             )}
 
+            {alertaFatigaId && !viajeBlockeado && (
+                <PantallaEsperando />
+            )}
+
             {viajeBlockeado && (
                 <PantallaBloqueo
-                    onContactarSupervisor={() => alert('Contactando con supervisor...\n\nUn representante se comunicará contigo a la brevedad para realizar la verificación manual.')}
+                    onContactarSupervisor={() => alert('Tu supervisor ya fue notificado del bloqueo. Revisá tus notificaciones para más información.')}
                 />
             )}
         </div>

--- a/src/meditrack-front/src/pages/Viajes/Viajes.jsx
+++ b/src/meditrack-front/src/pages/Viajes/Viajes.jsx
@@ -320,16 +320,17 @@ function Viajes() {
     const alertaFatigaIdRef = useRef(alertaFatigaId);
     useEffect(() => { alertaFatigaIdRef.current = alertaFatigaId; }, [alertaFatigaId]);
 
-    useNotificacionesWS(user?.id, user?.token, useCallback((notif) => {
+    const userId = user?.id;
+    useNotificacionesWS(userId, user?.token, useCallback((notif) => {
         if (notif.tipo !== 'DECISION_FATIGA' || !alertaFatigaIdRef.current) return;
         setAlertaFatigaId(null);
         if (notif.decision === 'BLOQUEADO') {
-            getUsuarioById(user.id)
+            getUsuarioById(userId)
                 .then(u => updateUser({ estaBloqueado: u.estaBloqueado, fechaBloqueo: u.fechaBloqueo }))
                 .catch(() => {});
             setViajeBlockeado(true);
         }
-    }, [user?.id, updateUser]));
+    }, [userId, updateUser]));
 
     useEffect(() => {
         setViajeBlockeado(isBlocked());

--- a/src/meditrack-front/src/services/api.js
+++ b/src/meditrack-front/src/services/api.js
@@ -613,6 +613,54 @@ export async function desbloquearUsuario(id) {
   return res.json();
 }
 
+export async function reportarFatiga() {
+  const res = await fetch(`${BASE_URL}/api/alertas-fatiga`, {
+    method: 'POST',
+    headers: { ...getAuthHeaders() },
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Error al reportar evento de fatiga');
+  }
+  return res.json();
+}
+
+export async function getMiAlertaPendiente() {
+  const res = await fetch(`${BASE_URL}/api/alertas-fatiga/mi-alerta-pendiente`, {
+    headers: { ...getAuthHeaders() },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getAlertaFatiga(id) {
+  const res = await fetch(`${BASE_URL}/api/alertas-fatiga/${id}`, {
+    headers: { ...getAuthHeaders() },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getAlertasFatiga() {
+  const res = await fetch(`${BASE_URL}/api/alertas-fatiga`, {
+    headers: { ...getAuthHeaders() },
+  });
+  if (!res.ok) throw new Error('Error al obtener alertas de fatiga');
+  return res.json();
+}
+
+export async function procesarDecisionFatiga(alertaId, { decision, observaciones }) {
+  const res = await fetch(`${BASE_URL}/api/alertas-fatiga/${alertaId}/decision`, {
+    method: 'PUT',
+    headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ decision, observaciones }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Error al procesar decisión');
+  }
+  return res.json();
+}
 
 export async function getRutas() {
   if (!isOnline()) {


### PR DESCRIPTION
## Contexto y motivación

Anteriormente, cuando un repartidor no superaba la validación de aptitud por voz (2 intentos fallidos), el sistema lo **bloqueaba automáticamente** sin intervención humana. Este comportamiento presenta un problema ético significativo: una resolución que afecta directamente la capacidad de trabajo de una persona era tomada de forma autónoma por un algoritmo de IA, sin posibilidad de revisión ni consideración de factores externos (falla técnica del micrófono, ruido ambiental, problemas de conectividad con la API de Hugging Face, etc.).

Este PR elimina el bloqueo automático e implementa un **flujo completo de supervisión humana**.

## Flujo nuevo

```
DETECCIÓN               ALERTA                  RESOLUCIÓN            REGISTRO
─────────────────────────────────────────────────────────────────────────────
Repartidor falla   →   POST /api/alertas-   →   Supervisor recibe  →  BD guarda decisión
2 intentos de voz      fatiga                   notificación WS       con quién, cuándo
                                                en tiempo real        y por qué
                        Backend crea
                        AlertaFatiga             Supervisor decide:
                        (PENDIENTE)              ┌─ BLOQUEAR (6hs)
                                                 └─ VALIDAR FALLA
Repartidor ve
pantalla de espera  ←  WS notifica al   ←────────────────────────────────
(no bloqueado aún)      repartidor con
                        la decisión
```

## Cambios técnicos

### Backend — 5 archivos nuevos

| Archivo | Descripción |
|---|---|
| `model/EstadoAlertaFatiga.java` | Enum: `PENDIENTE`, `BLOQUEADO`, `VALIDADO_FALLA` |
| `model/AlertaFatiga.java` | Entidad con repartidor, supervisor, fechas, estado y observaciones |
| `repository/AlertaFatigaRepository.java` | Queries por estado y repartidor |
| `service/AlertaFatigaService.java` | Crea alertas, notifica supervisores, procesa decisiones |
| `controller/AlertaFatigaController.java` | REST endpoints |

**Endpoints nuevos:**
```
POST /api/alertas-fatiga                  → repartidor reporta evento de fatiga
GET  /api/alertas-fatiga                  → supervisor consulta todas las alertas
GET  /api/alertas-fatiga/pendientes       → supervisor consulta alertas pendientes
GET  /api/alertas-fatiga/mi-alerta-pendiente → repartidor consulta su estado al recargar
GET  /api/alertas-fatiga/{id}             → consulta de alerta por ID
PUT  /api/alertas-fatiga/{id}/decision    → supervisor registra su decisión
```

**Modificaciones en archivos existentes:**
- `NotificacionService.java`: nuevo overload `crearNotificacion(..., Map<String, Object> extraWsData)` para incluir campos adicionales en el payload WebSocket (como `tipo` y `decision`)
- `AlertaFatigaService`: cuando el supervisor bloquea, invoca al `usuarioService.bloquearUsuario()` ya existente — reutiliza toda la lógica de historial y registro

### Frontend — 6 archivos modificados + 1 nuevo

| Archivo | Cambio |
|---|---|
| `services/api.js` | +5 funciones: `reportarFatiga`, `getMiAlertaPendiente`, `getAlertaFatiga`, `getAlertasFatiga`, `procesarDecisionFatiga` |
| `Viajes.jsx` | `onBloqueado` llama `reportarFatiga()` en vez de `bloquearUsuario()`. Suscripción a WebSocket para reaccionar a la resolución del supervisor en tiempo real |
| `ModalValidacionAptitud.jsx` | Nuevo componente `PantallaEsperando` (presentacional, sin polling). `PantallaBloqueo` actualiza su texto |
| `pages/Fatiga/AlertasFatiga.jsx` | **Página nueva** para supervisores con tabla de alertas y modal de resolución |
| `App.jsx` | Ruta `/alertas-fatiga` protegida para `SUPERVISOR` y `ADMINISTRADOR` |
| `MainMenu.jsx` | Botón "Alertas Fatiga" en la sección Repartidores (solo visible para supervisor/admin) |

### Decisión de diseño: WebSocket en lugar de polling

La pantalla de espera del repartidor no usa polling al backend. Cuando el supervisor decide, `AlertaFatigaService` envía al repartidor una notificación WebSocket con campos extra `{ tipo: "DECISION_FATIGA", decision: "BLOQUEADO"/"VALIDADO_FALLA" }`. `Viajes.jsx` intercepta esa notificación a través del hook `useNotificacionesWS` ya existente y actualiza el estado de la UI instantáneamente.

### Persistencia al recargar

Si el repartidor recarga la página mientras su alerta está pendiente, `Viajes.jsx` consulta `GET /api/alertas-fatiga/mi-alerta-pendiente` al montar y restaura la pantalla de espera automáticamente.

## Implicancias éticas

- **Ningún repartidor puede ser bloqueado automáticamente** por el sistema sin intervención humana
- **Toda resolución queda registrada** en la tabla `alertas_fatiga` con el supervisor responsable, timestamp y observaciones (obligatorias)
- **Se distingue la falla técnica de la fatiga real**: el supervisor puede marcar `VALIDADO_FALLA` cuando el problema fue externo al estado del repartidor
- **Transparencia**: el repartidor recibe una notificación con el motivo de la decisión